### PR TITLE
Compile index.coffee to index.js after install

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Validate a newline limit policy",
   "main": "index.js",
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "postinstall": "coffee -c index.coffee"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes error "cannot find module 'coffeelint-limit-newlines'". Error occurs for users who run "npm install" because main index.js file is missing.
